### PR TITLE
use addthis for sharing

### DIFF
--- a/source/_includes/post/sharing.html
+++ b/source/_includes/post/sharing.html
@@ -1,11 +1,15 @@
 <div class="sharing">
+  <div class="addthis_toolbox addthis_default_style ">
+  {% if site.facebook_like %}
+  <a class="addthis_button_facebook_like" fb:like:layout="button_count"></a>
+  {% endif %}
   {% if site.twitter_tweet_button %}
-  <a href="http://twitter.com/share" class="twitter-share-button" data-url="{{ site.url }}{{ page.url }}" data-via="{{ site.twitter_user }}" data-counturl="{{ site.url }}{{ page.url }}" >Tweet</a>
+  <a class="addthis_button_tweet"></a>
   {% endif %}
   {% if site.google_plus_one %}
-  <div class="g-plusone" data-size="{{ site.google_plus_one_size }}"></div>
+  <a class="addthis_button_google_plusone" g:plusone:size="{{ site.google_plus_one_size }}"></a>
   {% endif %}
-  {% if site.facebook_like %}
-    <div class="fb-like" data-send="true" data-width="450" data-show-faces="false"></div>
-  {% endif %}
+  <a class="addthis_counter addthis_pill_style"></a>
+  </div>
+  <script type="text/javascript" src="http://s7.addthis.com/js/250/addthis_widget.js#pubid={{ site.addthis_profile_id }}"></script>
 </div>


### PR DESCRIPTION
Using AddThis for sharing gives a bit better analytics (if you sign up for an account) and also cleans up the sharing footer on posts. You can see what it looks like on my site, thought you might be interested.

It was taken as an idea from the greyshade theme, and I didn't add buttons for pinterest or anything else (which is technically possible) so do what you'd like with it.
