### PR TITLE
Fixed Disqus comments.

### DIFF
--- a/source/_includes/disqus.html
+++ b/source/_includes/disqus.html
@@ -5,7 +5,7 @@
       {% if page.comments == true %}
         {% comment %} `page.comments` can be only be set to true on pages/posts, so we embed the comments here. {% endcomment %}
         // var disqus_developer = 1;
-        var disqus_identifier = '{ site.url }}{{ page.url }}';
+        var disqus_identifier = '{{ site.url }}{{ page.url }}';
         var disqus_url = '{{ site.url }}{{ page.url }}';
         var disqus_script = 'embed.js';
       {% else %}


### PR DESCRIPTION
{{ site.url }} was missing a {, causing { site.url}} to be rendered instead of the intended URL.
