### PR TITLE
Update Linkedin url

### DIFF
--- a/source/_includes/navigation.html
+++ b/source/_includes/navigation.html
@@ -4,7 +4,7 @@
     <li><a href="http://github.com/{{ site.github_user }}" title="Github Profile"><i class="icon-github-sign social-navbar"></i></a></li>
     {% endif %}
     {% if site.linkedin_user %}
-    <li><a href="http://linkedin.com/in/{{ site.linkedin_user }}" title="Linkedin Profile"><i class="icon-linkedin-sign social-navbar"></i></a></li>
+    <li><a href="http://linkedin.com/pub/{{ site.linkedin_user }}" title="Linkedin Profile"><i class="icon-linkedin-sign social-navbar"></i></a></li>
     {% endif %}
     {% if site.twitter_user %}
     <li><a href="http://twitter.com/{{ site.twitter_user }}" title="Twitter Profile"><i class="icon-twitter-sign social-navbar"></i></a></li>


### PR DESCRIPTION
The public profile url for linkedin has changed. This fix updates the url
