### PR TITLE
Force hyphenation of {{ category }} links

### DIFF
--- a/source/_includes/article.html
+++ b/source/_includes/article.html
@@ -11,7 +11,7 @@
           {% if post.categories %}
           <div class="row-fluid">
           {% for category in post.categories %}
-          <a href="{{ root_url }}/{{ site.category_dir }}/{{ category }}/"><span class="badge">{{ category }}</span></a>
+          <a href="{{ root_url }}/{{ site.category_dir }}/{{ category | split: " " | join: "-" }}/"><span class="badge">{{ category }}</span></a>
           {% endfor %}
           </div>
           {% endif %}

--- a/source/_includes/post/categories.html
+++ b/source/_includes/post/categories.html
@@ -2,11 +2,11 @@
 {% unless category == '0' %}
 {% if post %}
 {% for category in post.categories %}
-  <a href="{{ root_url }}/{{ site.category_dir }}/{{ category }}/"><span class="badge">{{ category }}</span></a>
+  <a href="{{ root_url }}/{{ site.category_dir }}/{{ category | split: " " | join: "-" }}/"><span class="badge">{{ category }}</span></a>
 {% endfor %}
 {% else %}
 {% for category in page.categories %}
-  <a href="{{ root_url }}/{{ site.category_dir }}/{{ category }}/"><span class="badge">{{ category }}</span></a>
+  <a href="{{ root_url }}/{{ site.category_dir }}/{{ category | split: " " | join: "-" }}/"><span class="badge">{{ category }}</span></a>
 {% endfor %}
 {% endif %}
 {% endunless %}


### PR DESCRIPTION
Hey Alex,

Love the theme! I did, however, notice that my category links were broken. I tend to use long category names with spaces in them, so just having unprocessed {{ category }} in the anchor tags was no good. 

How about forcing hyphenation like this? It solved the issue for [my site](http://iamscottrogers.com), at least. You can see it in action there.

Thanks!

Scott
