### PR TITLE
Fix issue #28 color of `p code`

### DIFF
--- a/sass/_syntax.scss
+++ b/sass/_syntax.scss
@@ -96,10 +96,10 @@ p, li {
     @extend .mono;
     display: inline-block;
     white-space: no-wrap;
-    background: #fff;
-    font-size: .6em;
-    color: #555;
-    border: 1px solid #ddd;
+    background: $code-bg-color !important;
+    font-size: .8em;
+    color: $base1 !important;
+    border: none;
     @include border-radius(.4em);
     padding: 0 .3em;
     margin: -1px 0;


### PR DESCRIPTION
Would it look better with theme color?

After:

![screen shot 2013-11-17 at 12 13 03](https://f.cloud.github.com/assets/43471/1557955/c6580276-4f52-11e3-83b4-10f5ef8c4f43.png)

Before:

![screen shot 2013-11-17 at 11 24 34](https://f.cloud.github.com/assets/43471/1557956/c8a66c7a-4f52-11e3-8d88-fd5e75a6aaf2.png)
