### PR TITLE
use FontAwesome icon-envelope instead of icon-envelope-alt

### DIFF
--- a/source/_includes/navigation.html
+++ b/source/_includes/navigation.html
@@ -23,6 +23,6 @@
     {% endif %}
 
     {% if site.email %}
-    <li><a href="mailto:{{ site.email }}" title="Email"><i class="icon-envelope-alt social-navbar"></i></a></li>
+    <li><a href="mailto:{{ site.email }}" title="Email"><i class="icon-envelope social-navbar"></i></a></li>
     {% endif %}
 </ul>


### PR DESCRIPTION
When `email: test@email.com` line is added to `_config.rb`, the email icon placed in the navigation bar is `icon-envelope-alt`. This doesn't fit as well with the more solid-colored versions of the other (GitHub, LinkedIn, etc) icons.

The PR replaces `icon-envelope-alt` with `icon-envelope`.

Screenshots:
[Before](http://i.imgur.com/QKAPeve)
[After](http://i.imgur.com/0D5176r.png)
