### PR TITLE
Add navigation icon support for www.xing.com

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -95,6 +95,16 @@ Your username can be found by going to your profile page. On your info card at t
 Extract out your username from the link.
 www.linkedin.com/in/**username**/
 
+### XING Link ###
+To get the XING link to work, modify your _config.yml to have this line:
+
+```
+$ xing_user: username
+```
+
+Your username can be found by going to your profile page on XING. It's the part of the url after /profile.
+For instance if your profile page is http://www.xing.com/profile/John_Doe, John_Doe would be the username.
+
 ---------
 
 ## License ##

--- a/source/_includes/navigation.html
+++ b/source/_includes/navigation.html
@@ -1,5 +1,8 @@
 {% include custom/navigation.html %}
 <ul class="nav pull-right">
+    {% if site.xing_user %}
+    <li><a href="http://xing.com/profile/{{ site.xing_user }}" title="XING Profile"><i class="icon-xing-sign social-navbar"></i></a></li>
+    {% endif %}
     {% if site.github_user %}
     <li><a href="http://github.com/{{ site.github_user }}" title="Github Profile"><i class="icon-github-sign social-navbar"></i></a></li>
     {% endif %}


### PR DESCRIPTION
Hey Alex, 

thank you for making such an awesome theme. This PR adds support for the German social network XING (comparable to Linkedin) to the navigation bar. Fontawesome already supports the icons for XING. 

If that's too country specific for you, that's also ok for me. I would than make the modification only locally in my octopress installation, but I thought I might as well share it :-)

Cheerio
Björn
